### PR TITLE
Use correct status name `Completed` instead of `SUCCESSFUL`

### DIFF
--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -35,7 +35,7 @@ function Dashboard() {
     for (const up of userProgress) {
       if (!progress.has(up.exercise_name)) {
         progress.set(up.exercise_name, up.status)
-      } else if (progress.get(up.exercise_name) !== "SUCCESSFUL" && up.status === "SUCCESSFUL") {
+      } else if (progress.get(up.exercise_name) !== "SUCCESSFUL" && up.status === "Completed") {
         // Take any success
         progress.set(up.exercise_name, up.status)
       }


### PR DESCRIPTION
Currently, `progress.json` stores both complete and incomplete verifications. Using [my own old progress.json](https://github.com/git-mastery/progress/commit/3e557326f63ab5a87ba64ba518144523deb33a8a) as reference, this will correctly display the status of exercises that had multiple runs of `gitmastery verify` to `Completed`.