### PR TITLE
Update base URL

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,4 @@
-export const BASE_URL = "https://git-mastery.github.io";
+export const BASE_URL = "https://git-mastery.org";
 
 export const EXERCISES_DIRECTORY_URL = `${BASE_URL}/exercises-directory`;
 


### PR DESCRIPTION
Currently, progress-dashboard has an issue as it is trying to fetch exercises.json from the old domain, causing a 301 Moved Permanently error.

This change updates the `BASE_URL` to the new domain.