### PR TITLE
Fix dashboard table is not using the full page width

### DIFF
--- a/src/pages/dashboard/(username)/index.tsx
+++ b/src/pages/dashboard/(username)/index.tsx
@@ -121,7 +121,7 @@ function DashboardPage() {
   }, [isLoading, user, userProgress, exercises, parsedUserProgress, username]);
 
   return (
-    <div className="lg:w-[40%] my-16 mx-auto md:w-[60%] w-[80%]">
+    <div className="my-16 mx-auto lg:w-[80%] xl:w-[70%] 2xl:w-[60%] w-[85%]">
       <DashboardHeader username={username!} onRefresh={refreshUserProgress} />
       <div>{renderContent()}</div>
     </div>


### PR DESCRIPTION
Fixes #14 

Currently, the page works well for small devices, however there seems to be a max width of the container, thus is doesn't increase further after expanding the width further.

There are a two options:
* Only increase width of table (so it exceeds container width)
* Increase width of container itself -> this means the headers and nav components above will also expand in width

We have chosen to increase the width of the containers by adjusting the % for different width sizes.

Eg. full screen in 14 inch screen on MacOS

<img width="1796" height="1013" alt="image" src="https://github.com/user-attachments/assets/83d1b596-ffdf-42a5-82ac-85f0dea2ddf6" />

Eg. half screen in 14 inch screen on MacOS

<img width="896" height="1007" alt="image" src="https://github.com/user-attachments/assets/2d79c910-43fa-4c74-8fb5-b8c4f8379d31" />
